### PR TITLE
Adding .gitignore and requirements.txt files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,56 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# PyCharm
+.idea/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+praw
+pyimgur
+beautifulsoup4
+wikipedia


### PR DESCRIPTION
A `.gitignore` file should exist to keep contributors from accidently tracking files that should not be tracked, such as IDE project files.

A `requirements.txt` file makes installing all project dependencies easier by allowing all to be installed with one command (e.g. `pip install -r requirements.txt`).
